### PR TITLE
Fix forge-std imports

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -1,2 +1,2 @@
-forge-std/=node_modules/forge-std/src
+forge-std/=node_modules/forge-std/src/
 @openzeppelin/contracts/=node_modules/@openzeppelin/contracts/

--- a/script/Base.s.sol
+++ b/script/Base.s.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.29 <0.9.0;
 
-import { Script } from "forge-std/src/Script.sol";
+import { Script } from "forge-std/Script.sol";
 
 abstract contract BaseScript is Script {
     /// @dev Included to enable compilation of the script without a $MNEMONIC environment variable.

--- a/tests/Foo.t.sol
+++ b/tests/Foo.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.29 <0.9.0;
 
-import { Test } from "forge-std/src/Test.sol";
-import { console2 } from "forge-std/src/console2.sol";
+import { Test } from "forge-std/Test.sol";
+import { console2 } from "forge-std/console2.sol";
 
 import { Foo } from "../src/Foo.sol";
 


### PR DESCRIPTION
## Summary
- correct remapping for forge-std
- update imports to use `forge-std/` prefix

## Testing
- `bun run lint` *(fails: `forge` not found)*
- `bun run test` *(fails: `forge` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fae14b5ac832888bddc654950d2cf